### PR TITLE
a workaround to keep the app hidden from the dock

### DIFF
--- a/gh-notifications-osx.xcodeproj/project.pbxproj
+++ b/gh-notifications-osx.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "gh.gh-notifications-osx";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -334,7 +334,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.4;
+				MARKETING_VERSION = 1.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "gh.gh-notifications-osx";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
The app is brought to focus when notification is clicked on and this makes the app re-appear in the doc.
This is a dummy workaround to keep it hidden.